### PR TITLE
Fix invalid table reference

### DIFF
--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -154,8 +154,6 @@ pub enum Error {
 	DuplicatedSections(u8),
 	/// Invalid memory reference (should be 0).
 	InvalidMemoryReference(u8),
-	/// Invalid table reference (should be 0).
-	InvalidTableReference(u8),
 	/// Invalid value used for flags in limits type.
 	InvalidLimitsFlags(u8),
 	/// Unknown function form (should be 0x60).
@@ -206,8 +204,6 @@ impl fmt::Display for Error {
 			Error::DuplicatedSections(ref id) => write!(f, "Duplicated sections ({})", id),
 			Error::InvalidMemoryReference(ref mem_ref) =>
 				write!(f, "Invalid memory reference ({})", mem_ref),
-			Error::InvalidTableReference(ref table_ref) =>
-				write!(f, "Invalid table reference ({})", table_ref),
 			Error::InvalidLimitsFlags(ref flags) => write!(f, "Invalid limits flags ({})", flags),
 			Error::UnknownFunctionForm(ref form) => write!(f, "Unknown function form ({})", form),
 			Error::InconsistentCode =>
@@ -250,7 +246,6 @@ impl ::std::error::Error for Error {
 			Error::SectionsOutOfOrder => "Sections out of order",
 			Error::DuplicatedSections(_) => "Duplicated section",
 			Error::InvalidMemoryReference(_) => "Invalid memory reference",
-			Error::InvalidTableReference(_) => "Invalid table reference",
 			Error::InvalidLimitsFlags(_) => "Invalid limits flags",
 			Error::UnknownFunctionForm(_) => "Unknown function form",
 			Error::InconsistentCode =>

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -122,7 +122,7 @@ pub enum Instruction {
 	Return,
 
 	Call(u32),
-	CallIndirect(u32, u8),
+	CallIndirect(u32, u32),
 
 	Drop,
 	Select,
@@ -1088,7 +1088,7 @@ impl Deserialize for Instruction {
 
 			CALLINDIRECT => CallIndirect(
 				VarUint32::deserialize(reader)?.into(),
-				Uint8::deserialize(reader)?.into(),
+				VarUint32::deserialize(reader)?.into(),
 			),
 
 			DROP => Drop,
@@ -1780,7 +1780,7 @@ impl Serialize for Instruction {
 			}),
 			CallIndirect(index, reserved) => op!(writer, CALLINDIRECT, {
 				VarUint32::from(index).serialize(writer)?;
-				Uint8::from(reserved).serialize(writer)?;
+				VarUint32::from(reserved).serialize(writer)?;
 			}),
 			Drop => op!(writer, DROP),
 			Select => op!(writer, SELECT),
@@ -2392,7 +2392,7 @@ impl fmt::Display for Instruction {
 			BrTable(ref table) => fmt_op!(f, "br_table", table.default),
 			Return => fmt_op!(f, "return"),
 			Call(index) => fmt_op!(f, "call", index),
-			CallIndirect(index, _) => fmt_op!(f, "call_indirect", index),
+			CallIndirect(index, table_ref) => fmt_op!(f, "call_indirect", index, table_ref),
 			Drop => fmt_op!(f, "drop"),
 			Select => fmt_op!(f, "select"),
 			GetLocal(index) => fmt_op!(f, "get_local", index),

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -1085,15 +1085,12 @@ impl Deserialize for Instruction {
 			},
 			RETURN => Return,
 			CALL => Call(VarUint32::deserialize(reader)?.into()),
-			CALLINDIRECT => {
-				let signature: u32 = VarUint32::deserialize(reader)?.into();
-				let table_ref: u8 = Uint8::deserialize(reader)?.into();
-				if table_ref != 0 {
-					return Err(Error::InvalidTableReference(table_ref))
-				}
 
-				CallIndirect(signature, table_ref)
-			},
+			CALLINDIRECT => CallIndirect(
+				VarUint32::deserialize(reader)?.into(),
+				Uint8::deserialize(reader)?.into(),
+			),
+
 			DROP => Drop,
 			SELECT => Select,
 


### PR DESCRIPTION
# Motivation

With Wasm modules generated by Rust 1.82 onwards are used with `wasm-instrument`, an "Invalid table reference" error is frequently shown. This error seems outdated, because even though previously the table reference was supposed to always be zero, newer versions of WebAssembly support other table references.

# Proposal

Remove enforcement of zero as the table reference, and change the `CallIndirect` opcode representation to use unsigned 32-bit integers for the table index, in order to follow the [specification](https://webassembly.github.io/spec/core/binary/modules.html#binary-tableidx).