### PR TITLE
Prepare to release `0.45.1-linera.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "parity-wasm"
+name = "linera-parity-wasm"
 version = "0.45.1-linera.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Shulepov <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/paritytech/parity-wasm"
-homepage = "https://github.com/paritytech/parity-wasm"
-documentation = "https://docs.rs/parity-wasm"
+repository = "https://github.com/linera-io/parity-wasm"
+homepage = "https://github.com/linera-io/parity-wasm"
+documentation = "https://docs.rs/linera-parity-wasm"
 description = "WebAssembly low-level format library"
 keywords = ["wasm", "webassembly", "bytecode", "serde", "interpreter"]
 categories = ["wasm", "parser-implementations"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-wasm"
-version = "0.45.1"
+version = "0.45.1-linera.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Shulepov <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/examples/bench-decoder.rs
+++ b/examples/bench-decoder.rs
@@ -1,4 +1,4 @@
-extern crate parity_wasm;
+extern crate linera_parity_wasm;
 extern crate time;
 
 use std::fs;
@@ -12,7 +12,7 @@ fn rate(file_name: &'static str, iterations: u64) {
 
 	for _ in 0..iterations {
 		let start = Instant::now();
-		let _module = parity_wasm::deserialize_file(file_name);
+		let _module = linera_parity_wasm::deserialize_file(file_name);
 		let end = Instant::now();
 
 		total_ms += (end - start).whole_milliseconds();

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -2,11 +2,11 @@
 // Builder api introduced as a method for fast generation of
 // different small wasm modules.
 
-extern crate parity_wasm;
+extern crate linera_parity_wasm;
 
 use std::env;
 
-use parity_wasm::{builder, elements};
+use linera_parity_wasm::{builder, elements};
 
 fn main() {
 	// Example binary accepts one parameter which is the output file
@@ -14,7 +14,7 @@ fn main() {
 	let args = env::args().collect::<Vec<_>>();
 	if args.len() != 2 {
 		println!("Usage: {} output_file.wasm", args[0]);
-		return
+		return;
 	}
 
 	// Main entry for the builder api is the module function
@@ -44,5 +44,5 @@ fn main() {
 		.build();
 
 	// Module structure can be serialzed to produce a valid wasm file
-	parity_wasm::serialize_to_file(&args[1], module).unwrap();
+	linera_parity_wasm::serialize_to_file(&args[1], module).unwrap();
 }

--- a/examples/data.rs
+++ b/examples/data.rs
@@ -1,7 +1,7 @@
 // This short example provides the utility to inspect
 // wasm file data section.
 
-extern crate parity_wasm;
+extern crate linera_parity_wasm;
 
 use std::env;
 
@@ -11,12 +11,12 @@ fn main() {
 	let args = env::args().collect::<Vec<_>>();
 	if args.len() != 2 {
 		println!("Usage: {} somefile.wasm", args[0]);
-		return
+		return;
 	}
 
 	// Here we load module using dedicated for this purpose
 	// `deserialize_file` function (which works only with modules)
-	let module = parity_wasm::deserialize_file(&args[1]).expect("Failed to load module");
+	let module = linera_parity_wasm::deserialize_file(&args[1]).expect("Failed to load module");
 
 	// We query module for data section. Note that not every valid
 	// wasm module must contain a data section. So in case the provided

--- a/examples/exports.rs
+++ b/examples/exports.rs
@@ -1,11 +1,11 @@
 // This examples allow to query all function exports of the
 // provided wasm module
 
-extern crate parity_wasm;
+extern crate linera_parity_wasm;
 
 use std::env::args;
 
-use parity_wasm::elements::{External, FunctionType, Internal, Module, Type};
+use linera_parity_wasm::elements::{External, FunctionType, Internal, Module, Type};
 
 // Auxillary function to resolve function type (signature) given it's callable index
 fn type_by_index(module: &Module, index: usize) -> FunctionType {
@@ -48,12 +48,12 @@ fn main() {
 	if args.len() < 2 {
 		println!("Prints export function names with and their types");
 		println!("Usage: {} <wasm file>", args[0]);
-		return
+		return;
 	}
 
 	// Here we load module using dedicated for this purpose
 	// `deserialize_file` function (which works only with modules)
-	let module = parity_wasm::deserialize_file(&args[1]).expect("File to be deserialized");
+	let module = linera_parity_wasm::deserialize_file(&args[1]).expect("File to be deserialized");
 
 	// Query the export section from the loaded module. Note that not every
 	// wasm module obliged to contain export section. So in case there is no

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -1,16 +1,16 @@
-extern crate parity_wasm;
+extern crate linera_parity_wasm;
 
-use parity_wasm::elements::Section;
+use linera_parity_wasm::elements::Section;
 use std::env;
 
 fn main() {
 	let args = env::args().collect::<Vec<_>>();
 	if args.len() != 2 {
 		println!("Usage: {} somefile.wasm", args[0]);
-		return
+		return;
 	}
 
-	let module = parity_wasm::deserialize_file(&args[1]).expect("Failed to load module");
+	let module = linera_parity_wasm::deserialize_file(&args[1]).expect("Failed to load module");
 
 	println!("Module sections: {}", module.sections().len());
 

--- a/examples/inject.rs
+++ b/examples/inject.rs
@@ -1,11 +1,11 @@
-extern crate parity_wasm;
+extern crate linera_parity_wasm;
 
 use std::env;
 
-use parity_wasm::{builder, elements};
+use linera_parity_wasm::{builder, elements};
 
 pub fn inject_nop(instructions: &mut elements::Instructions) {
-	use parity_wasm::elements::Instruction::*;
+	use linera_parity_wasm::elements::Instruction::*;
 	let instructions = instructions.elements_mut();
 	let mut position = 0;
 	loop {
@@ -16,7 +16,7 @@ pub fn inject_nop(instructions: &mut elements::Instructions) {
 
 		position += 1;
 		if position >= instructions.len() {
-			break
+			break;
 		}
 	}
 }
@@ -25,10 +25,10 @@ fn main() {
 	let args = env::args().collect::<Vec<_>>();
 	if args.len() != 3 {
 		println!("Usage: {} input_file.wasm output_file.wasm", args[0]);
-		return
+		return;
 	}
 
-	let mut module = parity_wasm::deserialize_file(&args[1]).unwrap();
+	let mut module = linera_parity_wasm::deserialize_file(&args[1]).unwrap();
 
 	for section in module.sections_mut() {
 		if let elements::Section::Code(ref mut code_section) = *section {
@@ -44,5 +44,5 @@ fn main() {
 	);
 	let build = build.import().module("env").field("log").external().func(import_sig).build();
 
-	parity_wasm::serialize_to_file(&args[2], build.build()).unwrap();
+	linera_parity_wasm::serialize_to_file(&args[2], build.build()).unwrap();
 }

--- a/examples/roundtrip.rs
+++ b/examples/roundtrip.rs
@@ -1,4 +1,4 @@
-extern crate parity_wasm;
+extern crate linera_parity_wasm;
 
 use std::env;
 
@@ -6,10 +6,10 @@ fn main() {
 	let args = env::args().collect::<Vec<_>>();
 	if args.len() != 3 {
 		println!("Usage: {} in.wasm out.wasm", args[0]);
-		return
+		return;
 	}
 
-	let module = match parity_wasm::deserialize_file(&args[1])
+	let module = match linera_parity_wasm::deserialize_file(&args[1])
 		.expect("Failed to load module")
 		.parse_names()
 		.and_then(|module| module.parse_reloc())
@@ -23,5 +23,5 @@ fn main() {
 		},
 	};
 
-	parity_wasm::serialize_to_file(&args[2], module).expect("Failed to write module");
+	linera_parity_wasm::serialize_to_file(&args[2], module).expect("Failed to write module");
 }

--- a/examples/show.rs
+++ b/examples/show.rs
@@ -1,4 +1,4 @@
-extern crate parity_wasm;
+extern crate linera_parity_wasm;
 
 use std::env;
 
@@ -6,10 +6,10 @@ fn main() {
 	let args = env::args().collect::<Vec<_>>();
 	if args.len() != 3 {
 		println!("Usage: {} <wasm file> <index of function>", args[0]);
-		return
+		return;
 	}
 
-	let module = parity_wasm::deserialize_file(&args[1]).expect("Failed to load module");
+	let module = linera_parity_wasm::deserialize_file(&args[1]).expect("Failed to load module");
 	let function_index = args[2].parse::<usize>().expect("Failed to parse function index");
 
 	if module.code_section().is_none() {

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -17,6 +17,7 @@ test-generator = "0.3"
 
 [dependencies.parity-wasm]
 path = ".."
+package = "linera-parity-wasm"
 features = [
 	"atomics",
 	"simd",


### PR DESCRIPTION
# Motivation

The `parity-wasm` crate has been archived, but it's missing support for indirect calls to non-zero table indices. Therefore this fork was created, and now a version must be published on `creates.io`.

# Proposal

Change the name of the crate and create the first Linera-specific version.